### PR TITLE
Disable app sandboxing in Release.entitlements

### DIFF
--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>


### PR DESCRIPTION
Disable app sandboxing for the macOS Runner. Otherwise, Rust will fail to create the database.
