### PR TITLE
feat(a11y): add Semantics label + Key to home Add-Connection FAB

### DIFF
--- a/lib/generated/l10n/app_localizations.dart
+++ b/lib/generated/l10n/app_localizations.dart
@@ -2067,6 +2067,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.'**
   String get signPolicyManualDescription;
+
+  /// Semantics label for the FAB on the home screen that opens the Add Application flow.
+  ///
+  /// In en, this message translates to:
+  /// **'Add connection'**
+  String get addConnection;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/generated/l10n/app_localizations_ar.dart
+++ b/lib/generated/l10n/app_localizations_ar.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_az.dart
+++ b/lib/generated/l10n/app_localizations_az.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsAz extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_bg.dart
+++ b/lib/generated/l10n/app_localizations_bg.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_ca.dart
+++ b/lib/generated/l10n/app_localizations_ca.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_cs.dart
+++ b/lib/generated/l10n/app_localizations_cs.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_da.dart
+++ b/lib/generated/l10n/app_localizations_da.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_de.dart
+++ b/lib/generated/l10n/app_localizations_de.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_el.dart
+++ b/lib/generated/l10n/app_localizations_el.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_en.dart
+++ b/lib/generated/l10n/app_localizations_en.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_es.dart
+++ b/lib/generated/l10n/app_localizations_es.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_et.dart
+++ b/lib/generated/l10n/app_localizations_et.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_fa.dart
+++ b/lib/generated/l10n/app_localizations_fa.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_fr.dart
+++ b/lib/generated/l10n/app_localizations_fr.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_hi.dart
+++ b/lib/generated/l10n/app_localizations_hi.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_hu.dart
+++ b/lib/generated/l10n/app_localizations_hu.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_id.dart
+++ b/lib/generated/l10n/app_localizations_id.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_it.dart
+++ b/lib/generated/l10n/app_localizations_it.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_ja.dart
+++ b/lib/generated/l10n/app_localizations_ja.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_ko.dart
+++ b/lib/generated/l10n/app_localizations_ko.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_lv.dart
+++ b/lib/generated/l10n/app_localizations_lv.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_nl.dart
+++ b/lib/generated/l10n/app_localizations_nl.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_pl.dart
+++ b/lib/generated/l10n/app_localizations_pl.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_pt.dart
+++ b/lib/generated/l10n/app_localizations_pt.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_ru.dart
+++ b/lib/generated/l10n/app_localizations_ru.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_sv.dart
+++ b/lib/generated/l10n/app_localizations_sv.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_th.dart
+++ b/lib/generated/l10n/app_localizations_th.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_tr.dart
+++ b/lib/generated/l10n/app_localizations_tr.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_uk.dart
+++ b/lib/generated/l10n/app_localizations_uk.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_ur.dart
+++ b/lib/generated/l10n/app_localizations_ur.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_vi.dart
+++ b/lib/generated/l10n/app_localizations_vi.dart
@@ -1000,4 +1000,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get signPolicyManualDescription => 'Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/generated/l10n/app_localizations_zh.dart
+++ b/lib/generated/l10n/app_localizations_zh.dart
@@ -1812,4 +1812,7 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get activitiesLoadFailed => '載入活動失敗';
+
+  @override
+  String get addConnection => 'Add connection';
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -409,5 +409,9 @@
   "signPolicyBasic": "Basic",
   "signPolicyBasicDescription": "Brief wait to combine requests; you can use Always allow and Remember duration; remembered approvals still apply.",
   "signPolicyManual": "Manual",
-  "signPolicyManualDescription": "Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch."
+  "signPolicyManualDescription": "Opens the approval screen immediately; no remember shortcuts in the dialog; time-based remembered approvals are ignored so you confirm each batch.",
+  "addConnection": "Add connection",
+  "@addConnection": {
+    "description": "Semantics label for the FAB on the home screen that opens the Add Application flow."
+  }
 }

--- a/lib/pages/application/application_home_content.dart
+++ b/lib/pages/application/application_home_content.dart
@@ -77,44 +77,49 @@ class ApplicationHomeContent extends StatelessWidget {
   }
 
   Widget _buildFab(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        if (selectedSegment == 1) {
+    return Semantics(
+      button: true,
+      label: AppLocalizations.of(context)!.addConnection,
+      child: GestureDetector(
+        key: const Key('add_application_fab'),
+        onTap: () {
+          if (selectedSegment == 1) {
+            AegisNavigator.pushPage(
+              context,
+              (context) => const BrowserPage(),
+            );
+            return;
+          }
+          final account = Account.sharedInstance;
+          final isEmpty = account.currentPubkey.isEmpty ||
+              account.currentPrivkey.isEmpty;
           AegisNavigator.pushPage(
             context,
-            (context) => const BrowserPage(),
+            (context) =>
+                isEmpty ? const Login() : const AddApplication(),
           );
-          return;
-        }
-        final account = Account.sharedInstance;
-        final isEmpty = account.currentPubkey.isEmpty ||
-            account.currentPrivkey.isEmpty;
-        AegisNavigator.pushPage(
-          context,
-          (context) =>
-              isEmpty ? const Login() : const AddApplication(),
-        );
-      },
-      child: Container(
-        width: 56,
-        height: 56,
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.secondaryContainer,
-          borderRadius: BorderRadius.circular(56),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withAlpha((0.14 * 255).round()),
-              offset: const Offset(0, 4),
-              blurRadius: 8,
-              spreadRadius: 1,
+        },
+        child: Container(
+          width: 56,
+          height: 56,
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.secondaryContainer,
+            borderRadius: BorderRadius.circular(56),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withAlpha((0.14 * 255).round()),
+                offset: const Offset(0, 4),
+                blurRadius: 8,
+                spreadRadius: 1,
+              ),
+            ],
+          ),
+          child: Center(
+            child: CommonImage(
+              iconName: 'add_icon.png',
+              size: 36,
+              color: Theme.of(context).colorScheme.onSecondaryContainer,
             ),
-          ],
-        ),
-        child: Center(
-          child: CommonImage(
-            iconName: 'add_icon.png',
-            size: 36,
-            color: Theme.of(context).colorScheme.onSecondaryContainer,
           ),
         ),
       ),


### PR DESCRIPTION
## What this PR does

Wraps the home-screen FAB used to add a new application connection in a `Semantics(button: true, label: 10n.addConnection)` widget and assigns it a stable `Key('add_application_fab')`.

Files touched:
- `lib/pages/application/application_home_content.dart` — wraps the existing `GestureDetector` in `Semantics` + adds the `Key`.
- `lib/l10n/app_en.arb` — adds the `addConnection` ARB entry (`"Add connection"`) with a `@addConnection` description.
- All other `lib/l10n/app_*.arb` — adds the same key with the English string as a placeholder + a `TODO: translate` description so generated bindings stay valid. **Not translated** — happy to leave that to your translation workflow.
- `lib/generated/l10n/app_localizations*.dart` — minimal manual addition of the new getter (matches the existing generator output style; each per-locale class returns `'Add connection'` until proper translations are added).

## Why

[Lightning Piggy Mobile](https://github.com/BenGWeeks/lightning-piggy-mobile) is integrating Aegis as a NIP-46 remote signer for users who want their nsec held outside the wallet. The integration ships with a Maestro E2E test suite that drives the signer end-to-end — but there was no way to locate this FAB from automation:

- It's a bare `GestureDetector` wrapping a styled `Container` with no text label, no `tooltip`, no `Semantics`, and no `Key`.
- TalkBack therefore can't announce it for blind users — it just reads out nothing when focused.
- WidgetTester / integration_test / Maestro / Appium can't find it without resorting to coordinate taps, which break across screen sizes and devices.

A `Semantics(button: true, label: ...)` wrapper fixes both at once: the abel is what TalkBack speaks ("Add connection, button") and what on-device automation tools see in the accessibility tree.

## Verification

Built and ran locally on Linux against an Android x86_64 emulator with the change applied. Confirmed:

- App launches normally and FAB renders unchanged visually (it's still the same purple circle with the `+` icon — `Semantics` is a zero-pixel wrapper).
- Maestro 2.3.0 can now drive the FAB. Working selector:

  ```
  yaml
  - tapOn: "Add connection"
  ```

This matches the `Semantics.label`. A direct `id: add_application_fab` selector (against the `Key`) doesn't surface through Flutter's a11y bridge to Maestro — the `Key` is mainly useful for in-process `WidgetTester.byKey(...)` from `integration_test`. Both improvements are valuable to keep, but the `Semantics` label is what unblocks cross-tool automation.

## Scope

Kept this intentionally minimal — one widget, one new l10n key. There are a few similar bare-`GestureDetector` / unlabelled `IconButton` spots elsewhere in the post-login flow (AppBar buttons, AddApplication method
cards) that would benefit from the same treatment for both TalkBack and test automation. Happy to follow up with a separate PR for those if you'd like — wanted to check this one is in the spirit of what you'd accept first.